### PR TITLE
Few ActiveRecord 5 fixes

### DIFF
--- a/lib/active_record/connection_adapters/em_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/em_mysql2_adapter.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+﻿# encoding: utf-8
 
 # AR adapter for using a fibered mysql2 connection with EM
 # This adapter should be used within Thin or Unicorn with the rack-fiber_pool middleware.
@@ -28,9 +28,17 @@ module ActiveRecord
     class EmMysql2Adapter < Mysql2Adapter
       ADAPTER_NAME = 'EmMySql2'
 
-      class Column < AbstractMysqlAdapter::Column # :nodoc:
-        def adapter
-          EmMysql2Adapter
+      if defined? MySQL::Column
+        class Column < MySQL::Column # :nodoc:
+          def adapter
+            EmMysql2Adapter
+          end
+        end
+      else
+        class Column < AbstractMysqlAdapter::Column # :nodoc:
+          def adapter
+            EmMysql2Adapter
+          end
         end
       end
 

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -1,4 +1,4 @@
-﻿require 'active_record'
+require 'active_record'
 require 'em-synchrony'
 
 ActiveSupport.on_load(:active_record) do


### PR DESCRIPTION
Some fixes to make it possible for EM-Synchrony to work with AR5.

See Rails changes in connection pool: rails/rails@603fe20#diff-7735c67f539e7d1e2908a4d5d8909c24 , and in AbstractMysqlAdapter: https://github.com/rails/rails/commit/83026cb15d76ee566dd95a2105d6ccbd57644369

P.S.: I'm not Rails Pro, so errors may be. But it works for me.
